### PR TITLE
Improved installation steps in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Update: now Python 3 compatible
 
 ### Install using pip
 
-    $ pip install django-liststyle
+    $ pip install django-liststyle==0.2b
 
-### Add liststyle to your settings
+### Add liststyle to your settings BEFORE django.contrib.admin
 
     INSTALLED_APPS = {
         ...
         'liststyle',
+        ...
+        'django.contrib.admin',
         ...
     }
 


### PR DESCRIPTION
- liststyle must be before django.contrib.admin in INSTALLED_APPS
- pip install django-liststyle installs 0.1 and not 0.2b by default